### PR TITLE
Fix: Modifiers "bold", "italic" not applied via base16_color_modifiers when termguicolors == false

### DIFF
--- a/autoload/base16.vim
+++ b/autoload/base16.vim
@@ -44,8 +44,14 @@ function! base16#highlight(bang, group, ...)
   endif
   if len(l:attrs) > 0
     execute 'highlight' a:group 'gui='.join(l:attrs, ',')
+      if !has('termguicolors') || !&termguicolors
+        execute 'highlight' a:group 'cterm='.join(l:attrs, ',')
+      endif
   elseif a:bang
     execute 'highlight' a:group 'gui=NONE'
+      if !has('termguicolors') || !&termguicolors
+        execute 'highlight' a:group 'cterm=NONE'
+      endif
   endif
 endfunction
 


### PR DESCRIPTION
c.f. https://github.com/Soares/base16.nvim/issues/6
