### PR TITLE
Fix: Modifiers "bold", "italic" not applied via base16_color_modifiers when termguicolors == false

### DIFF
--- a/autoload/base16.vim
+++ b/autoload/base16.vim
@@ -6,6 +6,7 @@ function! base16#highlight(bang, group, ...)
     echohl None
     return
   endif
+  let l:termguicolors = (has('termguicolors') && &termguicolors)
   let l:fg = 0
   let l:bg = 0
   let l:sp = 0
@@ -15,14 +16,14 @@ function! base16#highlight(bang, group, ...)
       let l:fg = 1
       let [l:gui, l:cterm] = s:Color(l:arg[3:])
       execute 'highlight' a:group 'guifg='.l:gui
-      if !has('termguicolors') || !&termguicolors
+      if !termguicolors
         execute 'highlight' a:group 'ctermfg='.l:cterm
       endif
     elseif l:arg =~? '^bg='
       let l:bg = 1
       let [l:gui, l:cterm] = s:Color(l:arg[3:])
       execute 'highlight' a:group 'guibg='.l:gui
-      if !has('termguicolors') || !&termguicolors
+      if !termguicolors
         execute 'highlight' a:group 'ctermbg='.l:cterm
       endif
     elseif l:arg =~? '^sp='
@@ -44,12 +45,12 @@ function! base16#highlight(bang, group, ...)
   endif
   if len(l:attrs) > 0
     execute 'highlight' a:group 'gui='.join(l:attrs, ',')
-      if !has('termguicolors') || !&termguicolors
+      if !termguicolors
         execute 'highlight' a:group 'cterm='.join(l:attrs, ',')
       endif
   elseif a:bang
     execute 'highlight' a:group 'gui=NONE'
-      if !has('termguicolors') || !&termguicolors
+      if !termguicolors
         execute 'highlight' a:group 'cterm=NONE'
       endif
   endif

--- a/autoload/base16.vim
+++ b/autoload/base16.vim
@@ -44,8 +44,14 @@ function! base16#highlight(bang, group, ...)
   endif
   if len(l:attrs) > 0
     execute 'highlight' a:group 'gui='.join(l:attrs, ',')
+      if !has('termguicolors') || !&termguicolors
+        execute 'highlight' a:group 'cterm='.join(l:attrs, ',')
+      endif
   elseif a:bang
     execute 'highlight' a:group 'gui=NONE'
+      if !has('termguicolors') || !&termguicolors
+        execute 'highlight' a:group 'cterm=NONE'
+      endif
   endif
 endfunction
 


### PR DESCRIPTION
Attempt to fix [Modifiers "bold", "italic" not applied via base16_color_modifiers when termguicolors == false](https://github.com/Soares/base16.nvim/issues/6)